### PR TITLE
chore: add auto publish ci

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -11,6 +11,8 @@ name: Deno
 on:
   push:
     branches: ["main"]
+    tags:
+      - v*
   pull_request:
     branches: ["main"]
 
@@ -38,3 +40,19 @@ jobs:
 
       - name: Run tests
         run: deno task test
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: test
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - name: Publish lib
+        run: deno publish


### PR DESCRIPTION
https://jsr.io/docs/publishing-packages#publishing-from-github-actions

add jsr auto publish ci. when new tag is made, it will publish lib to jsr